### PR TITLE
Python 3.7 support. Fix a few warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-    - "pypy-5.3.1"
+    - "3.7-dev"
+    - "pypy3"
 # command to install dependencies
 install:
     - "pip install bitstring>=3.1.3"

--- a/pybufrkit/coder.py
+++ b/pybufrkit/coder.py
@@ -580,7 +580,7 @@ class Coder(object):
             self.process_constant(state, bit_operator, descriptor, 0)
 
         else:  # TODO: 241, 242, 243
-            raise NotImplemented('Operator Descriptor {} not implemented'.format(descriptor))
+            raise NotImplementedError('Operator Descriptor {} not implemented'.format(descriptor))
 
     def process_sequence_descriptor(self, state, bit_operator, descriptor):
         self.process_members(state, bit_operator, descriptor.members)

--- a/pybufrkit/tables.py
+++ b/pybufrkit/tables.py
@@ -37,6 +37,7 @@ from pybufrkit.descriptors import (ElementDescriptor,
                                    FixedReplicationDescriptor, DelayedReplicationDescriptor,
                                    OperatorDescriptor, SequenceDescriptor, BufrTemplate,
                                    UndefinedElementDescriptor, UndefinedSequenceDescriptor)
+from pybufrkit.utils import generate_quiet
 
 __all__ = ['TableGroupKey', 'get_table_group', 'get_table_group_by_key']
 
@@ -101,7 +102,7 @@ def normalize_tables_sn(tables_root_dir,
 
     # Ensure the master table number exists
     if not os.path.isdir(os.path.join(tables_root_dir, master_table_number_string)):
-        log.warn('Fallback to default master table number: {} ({} not found)'.format(
+        log.warning('Fallback to default master table number: {} ({} not found)'.format(
             DEFAULT_MASTER_TABLE_NUMBER, master_table_number_string
         ))
         master_table_number_string = str(DEFAULT_MASTER_TABLE_NUMBER)
@@ -115,7 +116,7 @@ def normalize_tables_sn(tables_root_dir,
                                   )):
         wmo_tables_sn = (master_table_number_string, centres, master_table_version_string)
     else:
-        log.warn('Fallback to default master table version {} ({} not found)'.format(
+        log.warning('Fallback to default master table version {} ({} not found)'.format(
             DEFAULT_MASTER_TABLE_VERSION, master_table_version_string
         ))
         wmo_tables_sn = (master_table_number_string, centres, str(DEFAULT_MASTER_TABLE_VERSION))
@@ -133,12 +134,12 @@ def normalize_tables_sn(tables_root_dir,
                                           local_table_version_string)):
                 local_tables_sn = (master_table_number_string, centres, local_table_version_string)
                 if idx != 0:
-                    log.warn('Fallback to default local sub-centre {} ({} not found)'.format(
+                    log.warning('Fallback to default local sub-centre {} ({} not found)'.format(
                         DEFAULT_ORIGINATING_SUBCENTRE, originating_subcentre
                     ))
                 break
         else:
-            log.warn('Cannot find sub-centre {} nor valid default. Local table not in use.'.format(
+            log.warning('Cannot find sub-centre {} nor valid default. Local table not in use.'.format(
                 originating_subcentre
             ))
             local_tables_sn = None
@@ -291,7 +292,7 @@ def _descriptors_from_ids_iter(b, c, r, d, next_id):
             if isinstance(descriptor, DelayedReplicationDescriptor):
                 descriptor.factor = b.lookup(next_id())
 
-            g = (next_id() for _ in range(descriptor.n_items))
+            g = generate_quiet(range(descriptor.n_items), next_id)
             # TODO: check whether the actual number of members equals to n_items
             descriptor.members = _descriptors_from_ids_iter(b, c, r, d, functools.partial(next, g))
             descriptors.append(descriptor)

--- a/pybufrkit/templatedata.py
+++ b/pybufrkit/templatedata.py
@@ -370,7 +370,7 @@ class TemplateData(object):
             self.add_value_node()
 
         else:  # TODO: 241, 242, 243
-            raise NotImplemented('Operator Descriptor {} not implemented'.format(descriptor))
+            raise NotImplementedError('Operator Descriptor {} not implemented'.format(descriptor))
 
     def wire_skippable_local_descriptor(self):
         self.add_value_node()

--- a/pybufrkit/utils.py
+++ b/pybufrkit/utils.py
@@ -235,3 +235,16 @@ def subsets_nested_text_to_flat_json(lines, idxline):
             data_all_subsets[-1].append(value)
         idxline += 1
     return idxline, data_all_subsets
+
+
+def generate_quiet(iterable, next_val):
+    """
+    Iterate, returning if the generator function raises StopIteration.
+
+    https://www.python.org/dev/peps/pep-0479/
+    """
+    for _ in iterable:
+        try:
+            yield next_val()
+        except StopIteration:
+            return

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Utilities",
     ],
     keywords=['BUFR', 'WMO'],


### PR DESCRIPTION
@ywangd The only bugfix is in the handling of StopIteration from next_id() in tables._descriptors_from_ids, which became a RuntimeError in 3.7. These changes also silence related warnings in 3.6, and fix a few warnings I saw from py.test and pyflakes.