### PR TITLE
doc: denote conda-forge availability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,10 @@ To install from PyPi::
 
     pip install pybufrkit
 
+Or from `conda-forge <https://conda-forge.org>`_::
+
+    conda install -c conda-forge pybufrkit
+
 Or from source::
 
     python setup.py install


### PR DESCRIPTION
I've setup a [pybufrkit feedstock](https://github.com/conda-forge/pybufrkit-feedstock) on conda-forge and this PR adds a blurb to the README.rst to document its soon availability. 