### PR TITLE
Support for local tables in separated directory from root dir

### DIFF
--- a/pybufrkit/__init__.py
+++ b/pybufrkit/__init__.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import argparse
 import logging
+import os
 import sys
 
 from pybufrkit.commands import (command_compile,
@@ -61,6 +62,12 @@ def main():
 
     ap.add_argument('-t', '--tables-root-directory',
                     help='The directory to locate BUFR tables')
+
+    ap.add_argument('-l', '--tables-local-directory',
+                    help='The directory to locate local BUFR tables')
+
+    ap.add_argument('-p', '--tables-local-provider',
+                    help='The provider for local BUFR tables')
 
     subparsers = ap.add_subparsers(
         dest='command',
@@ -260,6 +267,10 @@ def main():
     update_tables_parser.add_argument('--overwrite', action='store_true', help='Overwrite existing tables')
 
     ns = ap.parse_args()
+
+    ns.tables_local_directory = ns.tables_local_directory or ns.tables_root_directory
+    if ns.tables_local_provider:
+        ns.tables_local_directory = os.path.join(ns.tables_local_directory, ns.tables_local_provider)
 
     if ns.info:
         logging_level = logging.INFO

--- a/pybufrkit/bufr.py
+++ b/pybufrkit/bufr.py
@@ -353,18 +353,20 @@ class BufrMessage(object):
         """
         self.sections.append(section)
 
-    def build_template(self, tables_root_dir, normalize=1):
+    def build_template(self, tables_root_dir, tables_local_dir=None, normalize=1):
         """
         Build the BufrTemplate object using the list of unexpanded descriptors
         and corresponding table group.
 
         :param tables_root_dir: The root directory to find BUFR tables
+        :param tables_local_dir: The root directory to find local BUFR tables
         :param normalize: Whether to use some default table group if the specific
             one is not available.
         :return: A tuple of BufrTemplate and the associated TableGroup
         """
         table_group = TableGroupCacheManager.get_table_group(
             tables_root_dir=tables_root_dir,
+            tables_local_dir=tables_local_dir,
             master_table_number=self.master_table_number.value,
             originating_centre=self.originating_centre.value,
             originating_subcentre=self.originating_subcentre.value,

--- a/pybufrkit/coder.py
+++ b/pybufrkit/coder.py
@@ -260,14 +260,17 @@ class Coder(object):
 
     :param definitions_dir: Where to find the BPCL definition files.
     :param tables_root_dir: Where to find the BUFR table files.
+    :param tables_local_dir: Where to find the local BUFR table files.
     """
 
     def __init__(self,
                  definitions_dir=None,
-                 tables_root_dir=None):
+                 tables_root_dir=None,
+                 tables_local_dir=None):
 
         self.section_configurer = SectionConfigurer(definitions_dir=definitions_dir)
         self.tables_root_dir = tables_root_dir or DEFAULT_TABLES_DIR
+        self.tables_local_dir = tables_local_dir or self.tables_root_dir
 
     @abc.abstractmethod
     def process(self, *args, **kwargs):

--- a/pybufrkit/commands.py
+++ b/pybufrkit/commands.py
@@ -36,6 +36,7 @@ def command_decode(ns):
     """
     decoder = Decoder(definitions_dir=ns.definitions_directory,
                       tables_root_dir=ns.tables_root_directory,
+                      tables_local_dir=ns.tables_local_directory,
                       compiled_template_cache_max=ns.compiled_template_cache_max)
 
     def show_message(m):
@@ -78,11 +79,13 @@ def command_info(ns):
     """
     flat_text_render = FlatTextRenderer()
     decoder = Decoder(definitions_dir=ns.definitions_directory,
-                      tables_root_dir=ns.tables_root_directory)
+                      tables_root_dir=ns.tables_root_directory,
+                      tables_local_dir=ns.tables_local_directory)
 
     def show_message_info(m):
         bufr_template, table_group = m.build_template(
-            ns.tables_root_directory, normalize=1)
+            ns.tables_root_directory,
+            ns.tables_local_directory, normalize=1)
 
         print(flat_text_render.render(m))
         if ns.template:
@@ -114,6 +117,7 @@ def command_encode(ns):
     """
     encoder = Encoder(definitions_dir=ns.definitions_directory,
                       tables_root_dir=ns.tables_root_directory,
+                      tables_local_dir=ns.tables_local_directory,
                       compiled_template_cache_max=ns.compiled_template_cache_max,
                       master_table_version=ns.master_table_version)
     if ns.filename != '-':
@@ -159,7 +163,8 @@ def command_split(ns):
     BufrMessage.
     """
     decoder = Decoder(definitions_dir=ns.definitions_directory,
-                      tables_root_dir=ns.tables_root_directory)
+                      tables_root_dir=ns.tables_root_directory,
+                      tables_local_dir=ns.tables_local_directory)
 
     for filename in ns.filenames:
         with open(filename, 'rb') as ins:
@@ -179,6 +184,7 @@ def command_lookup(ns):
     Command to lookup the given descriptors from command line
     """
     table_group = TableGroupCacheManager.get_table_group(ns.tables_root_directory,
+                                                         ns.tables_local_directory,
                                                          ns.master_table_number,
                                                          ns.originating_centre,
                                                          ns.originating_subcentre,
@@ -223,12 +229,15 @@ def command_compile(ns):
 
     if os.path.exists(ns.input):
         decoder = Decoder(definitions_dir=ns.definitions_directory,
-                          tables_root_dir=ns.tables_root_directory)
+                          tables_root_dir=ns.tables_root_directory,
+                          tables_local_dir=ns.tables_local_directory)
         with open(ns.input, 'rb') as ins:
             bufr_message = decoder.process(ins.read(), file_path=ns.input, info_only=True)
-            template, table_group = bufr_message.build_template(ns.tables_root_directory, normalize=1)
+            template, table_group = bufr_message.build_template(ns.tables_root_directory,
+                                                                ns.tables_local_directory, normalize=1)
     else:
         table_group = TableGroupCacheManager.get_table_group(ns.tables_root_directory,
+                                                             ns.tables_local_directory,
                                                              ns.master_table_number,
                                                              ns.originating_centre,
                                                              ns.originating_subcentre,
@@ -247,9 +256,11 @@ def command_subset(ns):
     """
     decoder = Decoder(definitions_dir=ns.definitions_directory,
                       tables_root_dir=ns.tables_root_directory,
+                      tables_local_dir=ns.tables_local_directory,
                       compiled_template_cache_max=ns.compiled_template_cache_max)
     encoder = Encoder(definitions_dir=ns.definitions_directory,
                       tables_root_dir=ns.tables_root_directory,
+                      tables_local_dir=ns.tables_local_directory,
                       compiled_template_cache_max=ns.compiled_template_cache_max)
 
     subset_indices = [int(x) for x in ns.subset_indices.split(',')]
@@ -272,6 +283,7 @@ def command_query(ns):
     """
     decoder = Decoder(definitions_dir=ns.definitions_directory,
                       tables_root_dir=ns.tables_root_directory,
+                      tables_local_dir=ns.tables_local_directory,
                       compiled_template_cache_max=ns.compiled_template_cache_max)
 
     for filename in ns.filenames:
@@ -322,6 +334,7 @@ def command_script(ns):
 
     decoder = Decoder(definitions_dir=ns.definitions_directory,
                       tables_root_dir=ns.tables_root_directory,
+                      tables_local_dir=ns.tables_local_directory,
                       compiled_template_cache_max=ns.compiled_template_cache_max)
 
     for filename in ns.filenames:

--- a/pybufrkit/decoder.py
+++ b/pybufrkit/decoder.py
@@ -44,9 +44,10 @@ class Decoder(Coder):
     def __init__(self,
                  definitions_dir=None,
                  tables_root_dir=None,
+                 tables_local_dir=None,
                  compiled_template_cache_max=None):
 
-        super(Decoder, self).__init__(definitions_dir, tables_root_dir)
+        super(Decoder, self).__init__(definitions_dir, tables_root_dir, tables_local_dir)
 
         # Only enable template compilation if cache is requested
         if compiled_template_cache_max is not None:
@@ -185,7 +186,7 @@ class Decoder(Coder):
         :return: TemplateData decoded from the bit stream.
         """
         # TODO: Parametrise the "normalize" argument
-        bufr_template, table_group = bufr_message.build_template(self.tables_root_dir, normalize=1)
+        bufr_template, table_group = bufr_message.build_template(self.tables_root_dir, self.tables_local_dir, normalize=1)
 
         state = CoderState(bufr_message.is_compressed.value, bufr_message.n_subsets.value)
 

--- a/pybufrkit/encoder.py
+++ b/pybufrkit/encoder.py
@@ -56,12 +56,13 @@ class Encoder(Coder):
     def __init__(self,
                  definitions_dir=None,
                  tables_root_dir=None,
+                 tables_local_dir=None,
                  ignore_declared_length=True,
                  compiled_template_cache_max=None,
                  master_table_number=None,
                  master_table_version=None):
 
-        super(Encoder, self).__init__(definitions_dir, tables_root_dir)
+        super(Encoder, self).__init__(definitions_dir, tables_root_dir, tables_local_dir)
         self.ignore_declared_length = ignore_declared_length
         self.overrides = {}
         if master_table_number:
@@ -223,7 +224,7 @@ class Encoder(Coder):
         :return:
         """
         # TODO: Parametrise the "normalize" argument
-        bufr_template, table_group = bufr_message.build_template(self.tables_root_dir, normalize=0)
+        bufr_template, table_group = bufr_message.build_template(self.tables_root_dir, self.tables_local_dir, normalize=0)
 
         state = CoderState(bufr_message.is_compressed.value, bufr_message.n_subsets.value, section_parameter.value)
 


### PR DESCRIPTION
Behavior change on command line tool:

New command line switches:

-l -> Path for local tables
-p -> Provider of local table


The user can select a separate path and provider for local tables.

Behavior change on library:
A new parameter was added to Encode and Decode classes: 
`tables_local_dir`: Path to search for local tables. Default is the same value as `tables_root_dir`. Here the path should already contain the `provider` of the table.

Suggest directory structure:
```
pybufrkit/tables
└── 0
    ├── 0_0
    └── 98_0

some_other_path/tables
└── 0
    ├── imd   <-- new local table with a provider name for selection
    │   └── 255_255
    └── meteofrance   <-- another new local table
    │   └── 42_0
    └── internal  <-- another new local table, with clashing table numbers with provider imd
        └── 255_255
```
