### PR TITLE
Fix header for BUFR version 2

### DIFF
--- a/pybufrkit/definitions/section1-2.json
+++ b/pybufrkit/definitions/section1-2.json
@@ -90,10 +90,11 @@
       "as_property": true
     },
     {
-      "name": "second",
-      "nbits": 8,
-      "type": "uint",
-      "as_property": true
+      "name": "local_bytes",
+      "nbits": 0,
+      "type": "bytes",
+      "as_property": true,
+      "optional": true
     }
   ]
 }

--- a/tests/test_optional_parameter_v2_even.py
+++ b/tests/test_optional_parameter_v2_even.py
@@ -1,0 +1,58 @@
+from pybufrkit.decoder import Decoder
+from pybufrkit.encoder import Encoder
+
+data = [
+    [
+        b'BUFR',
+        0,  # file length (will be calculated)
+        2
+    ],
+    [0,  # section length (will be calculated)
+     0,  # master table
+     0,  # centre
+     0,  # sequence number
+     False,  # has section 2 (no)
+     '0000000',  # flag bits
+     6,  # data category
+     0,  # data local subcategory
+     11,  # master table version
+     10,  # local table version
+     25,  # year
+     3,  # month
+     25,  # day
+     13,  # hour
+     45,  # min
+     b'localdata',  # Extra bytes
+    ],
+    [0,  # section length (will be calculated)
+     '00000000',  # reserved bits
+     1,  # subsets
+     True,  # is observation
+     False,  # is compressed
+     '000000',  # flag bits
+     # Definition follows
+     []
+     ],
+    [
+        0,  # section length (will be calculated)
+        '00000000',  # flag bits
+        [
+            [
+            ]  # flat data
+        ]
+    ],
+    [b'7777']
+]
+
+
+def test_optional_parameter_v2():
+    encoder = Encoder()
+    bufr_message = encoder.process(data)
+    print(bufr_message.serialized_bytes)
+    assert bufr_message.sections[1].section_length.value == 26
+    assert bufr_message.local_bytes.value == b'localdata'
+
+    decoder = Decoder()
+    decoded = decoder.process(bufr_message.serialized_bytes)
+    assert decoded.sections[1].section_length.value == 26
+    assert decoded.local_bytes.value == b'localdata'

--- a/tests/test_optional_parameter_v2_odd.py
+++ b/tests/test_optional_parameter_v2_odd.py
@@ -1,0 +1,58 @@
+from pybufrkit.decoder import Decoder
+from pybufrkit.encoder import Encoder
+
+data = [
+    [
+        b'BUFR',
+        0,  # file length (will be calculated)
+        2
+    ],
+    [0,  # section length (will be calculated)
+     0,  # master table
+     0,  # centre
+     0,  # sequence number
+     False,  # has section 2 (no)
+     '0000000',  # flag bits
+     6,  # data category
+     0,  # data local subcategory
+     11,  # master table version
+     10,  # local table version
+     25,  # year
+     3,  # month
+     25,  # day
+     13,  # hour
+     45,  # min
+     b'local_data',  # Extra bytes
+    ],
+    [0,  # section length (will be calculated)
+     '00000000',  # reserved bits
+     1,  # subsets
+     True,  # is observation
+     False,  # is compressed
+     '000000',  # flag bits
+     # Definition follows
+     []
+     ],
+    [
+        0,  # section length (will be calculated)
+        '00000000',  # flag bits
+        [
+            [
+            ]  # flat data
+        ]
+    ],
+    [b'7777']
+]
+
+
+def test_optional_parameter_v2():
+    encoder = Encoder()
+    bufr_message = encoder.process(data)
+    print(bufr_message.serialized_bytes)
+    assert bufr_message.sections[1].section_length.value == 28
+    assert bufr_message.local_bytes.value == b'local_data'
+
+    decoder = Decoder()
+    decoded = decoder.process(bufr_message.serialized_bytes)
+    assert decoded.sections[1].section_length.value == 28
+    assert decoded.local_bytes.value == b'local_data\x00'


### PR DESCRIPTION
According to:
 FM94-BUFR Encoding and Decoding Software
   User Guidelines
   Version 1.6
   For BUFR Software Version 3.1

The header for BUFR version 2 doesn't have second field. Extra bytes are allowed for local use